### PR TITLE
Feat/try postgres update 17

### DIFF
--- a/.platform/application.yml
+++ b/.platform/application.yml
@@ -11,7 +11,7 @@ relationalDatabase:
   - name: main
     engine:
       name: postgres
-      version: "14"
+      version: "17"
     highlyAvailable: false
     size: micro
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ echo 'export CPPFLAGS="-I/opt/homebrew/opt/php@7.1/include"' >> ~/.zshrc
 [composer](https://getcomposer.org/download/)
 
 ```sh
-php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"                                                                             ✘ INT
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 php -r "if (hash_file('sha384', 'composer-setup.php') === 'dac665fdc30fdd8ec78b38b9800061b4150413ff2e3b6f88543c636f7cd84f6db9189d43a81e5503cda447da73c7e5b6') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
 php composer-setup.php
 php -r "unlink('composer-setup.php');"
@@ -46,6 +46,10 @@ mv composer.phar /usr/local/bin/composer
 
 And then to get the dependencies:
 
+Note that you might encounter issues with `composer` requiring php 8.3 or higher. If that happens, you can run `brew install shivammathur/php/php@8.3` and make sure the path is set correctly in your `.zshrc` file. Check your version with `php -v`. re-source with `source ~/.zshrc` if needed.
+
+Then, run the following commands to install the dependencies:
+
 ```sh
 composer update
 composer install
@@ -53,7 +57,7 @@ composer install
 
 Create database table:
 
-```
+```sh
 php artisan migrate
 ```
 

--- a/README.md
+++ b/README.md
@@ -13,20 +13,20 @@ This repo is a laravel application that allows to run the following feature:
 
 Install dependencies
 
-Note that version 7.1 is required, which is a legacy version of PHP. These instructions are specific to
+Note that version 8.3 is required, which is a legacy version of PHP. These instructions are specific to
 MacOS. For other operating systems, please refer to their individual documentation for the relevant tools.
 
 ```sh
-brew install shivammathur/php/php@7.1
+brew install shivammathur/php/php@8.3
 ```
 
-Make sure to add php 7.1 to your path
+Make sure to add php 8.3 to your path
 
 ```sh
-echo 'export PATH="/opt/homebrew/opt/php@7.1/bin:$PATH"' >> ~/.zshrc
-echo 'export PATH="/opt/homebrew/opt/php@7.1/sbin:$PATH"' >> ~/.zshrc
-echo 'export LDFLAGS="-L/opt/homebrew/opt/php@7.1/lib"' >> ~/.zshrc
-echo 'export CPPFLAGS="-I/opt/homebrew/opt/php@7.1/include"' >> ~/.zshrc
+echo 'export PATH="/opt/homebrew/opt/php@8.3/bin:$PATH"' >> ~/.zshrc
+echo 'export PATH="/opt/homebrew/opt/php@8.3/sbin:$PATH"' >> ~/.zshrc
+echo 'export LDFLAGS="-L/opt/homebrew/opt/php@8.3/lib"' >> ~/.zshrc
+echo 'export CPPFLAGS="-I/opt/homebrew/opt/php@8.3/include"' >> ~/.zshrc
 ```
 
 [composer](https://getcomposer.org/download/)
@@ -45,10 +45,6 @@ mv composer.phar /usr/local/bin/composer
 ```
 
 And then to get the dependencies:
-
-Note that you might encounter issues with `composer` requiring php 8.3 or higher. If that happens, you can run `brew install shivammathur/php/php@8.3` and make sure the path is set correctly in your `.zshrc` file. Check your version with `php -v`. re-source with `source ~/.zshrc` if needed.
-
-Then, run the following commands to install the dependencies:
 
 ```sh
 composer update
@@ -69,7 +65,7 @@ To run locally the recommended way is to use [Valet](https://laravel.com/docs/8.
 composer global require laravel/valet:^2.1
 echo 'export PATH="~/.composer/vendor/bin:$PATH"' >> ~/.zshrc
 
-valet use php@7.1
+valet use php@8.3
 valet install
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
             DB_MAIN_PASSWORD: pass
 
     db:
-        image: postgres:12
+        image: postgres:17
         container_name: db
         restart: always
         volumes:


### PR DESCRIPTION
This PR:

- updates the readme for php 8.3 (a change done a while back)
- updates references to postgres 12 & 14 -> postgres 17 per the heroku warning:
```
This notification didn't send at May 28, 2025, 9:33 PM UTC. Review its details and check if your current systems are still experiencing problems now.
Your database (MAUVE on algolia-tools-backend-private) is on the deprecated Postgres version 14 that will reach end-of-life on 2025-Nov-28. To ensure your database has the best performance, security, and features, we recommend you upgrade to the latest Postgres version. Upgrading to a supported version is necessary to maintain the integrity and reliability of your service. If you don’t upgrade your Postgres version by 2025-Oct-28, we'll upgrade your database version to Postgres 17. See Upgrading the Version of a Heroku Postgres Database for more details, or open a support ticket if you have any questions.
```